### PR TITLE
Fix missing import for ProjectSelectPage

### DIFF
--- a/src/components/AppContainer.jsx
+++ b/src/components/AppContainer.jsx
@@ -13,6 +13,7 @@ import { AuthContext, AuthProvider } from '../AuthContext';
 import { SheetsDataContext } from '../contexts/SheetsDataContext';
 import ShotDetailPage from './ShotDetailPage';
 import AddShotPage from './AddShotPage'; // Import the new component
+import ProjectSelectPage from '../pages/ProjectSelectPage';
 import { appendField } from '../api/appendField';
 import { updateCell } from '../api/updateCell';
 import { updateNonUuidIds } from '../api/updateNonUuidIds';


### PR DESCRIPTION
## Summary
- import `ProjectSelectPage` in `AppContainer`

## Testing
- `npm run lint` *(fails: Key "no-dupe-imports" could not be found)*

------
https://chatgpt.com/codex/tasks/task_e_686cc543a7e4832db2f595c7aec878a4