### PR TITLE
Fix gapi initialization hang

### DIFF
--- a/src/AuthContext.jsx
+++ b/src/AuthContext.jsx
@@ -104,7 +104,6 @@ export const AuthProvider = ({ children, refreshData }) => {
 
     let refreshing = false;
     const waiters = [];
-    const PROMPT_REQUIRED = Symbol('PROMPT_REQUIRED');
     const SILENT_TIMEOUT_MS = 1000;
 
     const ensureValidToken = useCallback(() => {
@@ -157,13 +156,17 @@ export const AuthProvider = ({ children, refreshData }) => {
                 // 1. Initialize GAPI client
                 // ここではローカル discoveryDocs のみを使用 ※オンライン呼び出し禁止
                 const base = window.location.origin.replace(/\/$/, ''); // スラッシュ除去で二重 // 防止
-                await window.gapi.client.init({
-                    apiKey: API_KEY,
-                    discoveryDocs: [
-                        `${base}/drive_v3.json`,
-                        `${base}/sheets_v4.json`,
-                    ],
-                });
+                await withTimeout(
+                    window.gapi.client.init({
+                        apiKey: API_KEY,
+                        discoveryDocs: [
+                            `${base}/drive_v3.json`,
+                            `${base}/sheets_v4.json`,
+                        ],
+                    }),
+                    5000,
+                    'gapi.init'
+                );
                 console.log('[Auth] gapi.init done with local docs');
                 setGapiError(null); // Clear GAPI error on successful init
 


### PR DESCRIPTION
## Summary
- remove leftover file and duplicate symbol
- wrap `gapi.client.init` with a timeout so init can't hang

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686dcb2464d0832d88007af8c8e6b649