### PR TITLE
Add gapi proxy page

### DIFF
--- a/public/static/proxy.html
+++ b/public/static/proxy.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <script src="https://apis.google.com/js/api.js"></script>
+  </head>
+  <body></body>
+</html>


### PR DESCRIPTION
## Summary
- serve proxy.html so gapi can load

## Testing
- `npm run lint` *(fails: plugin import missing)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686dced2cac8832db3188ba70e723190