### PR TITLE
Fix Google API initialization cross-origin issue

### DIFF
--- a/src/AuthContext.jsx
+++ b/src/AuthContext.jsx
@@ -204,6 +204,9 @@ export const AuthProvider = ({ children, refreshData }) => {
 
         // GAPI load handler
         const handleGapiLoad = () => {
+            if (window.gapi?.iframes) {
+                window.gapi.iframes.CROSS_ORIGIN_PROXY_URI = '/static/proxy.html';
+            }
             window.gapi.load('client', () => {
                 gapiLoaded = true;
                 console.log('[Auth] GAPI script loaded.');


### PR DESCRIPTION
## Summary
- ensure gapi uses local proxy for iframe requests

## Testing
- `npm run lint` *(fails: plugin "import" missing)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686dd1cc6058832dbfbb4329479688df