### PR TITLE
Fix sign-in and project selection

### DIFF
--- a/src/AuthContext.jsx
+++ b/src/AuthContext.jsx
@@ -56,10 +56,10 @@ export const AuthProvider = ({ children, refreshData }) => {
   /* ---- GIS 初期化 -------------------------------------------- */
   useEffect(() => {
     /** step 1: スクリプトタグを確実に読み込む */
-    let gsi  = document.querySelector('script[src*="accounts.google.com/gsi/client"]');
-    if (gsi) {
-      gsi       = document.createElement('script');
-      gsi.src   = 'https://accounts.google.com/gsi/client';
+    let gsi = document.querySelector('script[src*="accounts.google.com/gsi/client"]');
+    if (!gsi) {
+      gsi = document.createElement('script');
+      gsi.src = 'https://accounts.google.com/gsi/client';
       gsi.async = true;
       gsi.defer = true;
       document.head.appendChild(gsi);
@@ -81,7 +81,6 @@ export const AuthProvider = ({ children, refreshData }) => {
             console.error('[Auth] token callback error', resp);
             setReAuth(true);
           }
-          setInit(true);                       // ← 成功・失敗に関わらず初期化完了
         },
       });
 
@@ -97,6 +96,7 @@ export const AuthProvider = ({ children, refreshData }) => {
           tokenClient.requestAccessToken({ prompt: 'consent' });
         },
       };
+      setInit(true);                       // GIS ready
     };
 
     /** step 3: スクリプトロード済なら即 init */

--- a/src/components/AppContainer.jsx
+++ b/src/components/AppContainer.jsx
@@ -11,6 +11,7 @@ import Toolbar from './Toolbar';
 import LoginButton from './LoginButton';
 import { AuthContext, AuthProvider } from '../AuthContext';
 import { SheetsDataContext } from '../contexts/SheetsDataContext';
+import { SheetsContext } from '../contexts/SheetsContext';
 import ShotDetailPage from './ShotDetailPage';
 import AddShotPage from './AddShotPage'; // Import the new component
 import ProjectSelectPage from '../pages/ProjectSelectPage';
@@ -39,9 +40,7 @@ export const AppContainer = () => {
   const { token, user, isInitialized, needsReAuth, signIn, ensureValidToken, error: authError } = useContext(AuthContext);
   const navigate = useNavigate();
 
-  const [sheetId, setSheetId] = useState(() => {
-    return localStorage.getItem('motk:lastSheetId') || null;
-  });
+  const { sheetId, setSheetId } = useContext(SheetsContext);
 
   const { sheets, fields, loading: fieldsLoading, error: fieldsError, refreshData, updateFieldOptions, idToColIndex } = useSheetsData(sheetId);
   const { pages, loading: pagesLoading, error: pagesError, refreshPages } = usePagesData(sheetId);
@@ -360,7 +359,7 @@ export const AppContainer = () => {
               </p>
             )}
             {!fieldsError && !pagesError && (
-              <SheetsDataContext.Provider value={{ sheets, fields, loading: fieldsLoading, error: fieldsError, refreshData, updateFieldOptions, idToColIndex }}>
+              <SheetsDataContext.Provider value={{ sheetId, setSheetId, sheets, fields, loading: fieldsLoading, error: fieldsError, refreshData, updateFieldOptions, idToColIndex }}>
                 <Routes>
                   <Route path="/signin" element={<LoginButton />} />
                   <Route path="/select" element={<ProjectSelectPage setSheetId={setSheetId} />} />

--- a/src/components/GlobalNav.jsx
+++ b/src/components/GlobalNav.jsx
@@ -9,11 +9,10 @@ import { AuthContext } from '../AuthContext';
 
 export default function GlobalNav() {
   const navigate = useNavigate();
-  const { token } = useContext(AuthContext);
   const { sheetId, setSheetId } = useContext(SheetsDataContext);
 
-  // 選択された sheetId を使って Drive → Sheets を取得
-  const { sheets, loading, error } = useDriveSheets(token, sheetId);
+  // Drive 上の MOTK プロジェクト一覧を取得
+  const { sheets, loading, error } = useDriveSheets();
   const [currentProjectDisplayName, setCurrentProjectDisplayName] = useState('Select Project');
   const [anchorEl, setAnchorEl] = useState(null);
   const open = Boolean(anchorEl);

--- a/src/hooks/useDriveSheets.js
+++ b/src/hooks/useDriveSheets.js
@@ -20,11 +20,10 @@ export const useDriveSheets = (sheetId = null) => {
       const res = await fetchGoogle('drive/v3/files', token, {
         pageSize: 100,
         fields: 'files(id,name,owners(displayName))',
-        q: [
-          "mimeType='application/vnd.google-apps.spreadsheet'",
-          "and trashed=false",
-          "and ('me' in owners or 'me' in writers or 'me' in readers)",
-        ].join(' '),
+        q:
+          "mimeType='application/vnd.google-apps.spreadsheet' " +
+          "and name contains 'MOTK[Project:' " +
+          "and ('me' in owners or 'me' in readers or 'me' in writers)",
       });
 
       setSheets(res.files ?? []);


### PR DESCRIPTION
## Summary
- load Google auth script when missing and mark init once ready
- share sheetId via context instead of local state
- only show MOTK formatted spreadsheets
- simplify project list hook usage

## Testing
- `npm run build`
- `npm run lint` *(fails: eslint-plugin-import missing)*

------
https://chatgpt.com/codex/tasks/task_e_686f91947c48832d9496a879128869d2