### PR TITLE
Fix login fetch CSP

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,7 +6,7 @@ const devCsp =
   "script-src 'self' 'unsafe-eval' 'unsafe-inline' blob: https://accounts.google.com/gsi/client; " +
   "style-src  'self' 'unsafe-inline' https://accounts.google.com/gsi/style; " +
   "frame-src  'self' https://accounts.google.com/gsi/; " +
-  "connect-src 'self' https://accounts.google.com/gsi/ https://www.googleapis.com;";
+  "connect-src 'self' https://accounts.google.com/gsi/ https://www.googleapis.com https://sheets.googleapis.com https://oauth2.googleapis.com;";
 
 export default defineConfig(({ command }) => ({
   plugins: [react()],


### PR DESCRIPTION
## Summary
- allow `sheets.googleapis.com` and `oauth2.googleapis.com` in dev server Content Security Policy

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686f9ddfb59c832d9aa5fbcb54c4ba4c