### PR TITLE
Fix Content Security Policy for Google Sheets API

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,10 @@
   <head>
     <meta charset="utf-8" />
     <title>MOTK Dev</title>
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="default-src 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline' blob: https://accounts.google.com/gsi/client; style-src 'self' 'unsafe-inline' https://accounts.google.com/gsi/style; frame-src 'self' https://accounts.google.com/gsi/; connect-src 'self' https://accounts.google.com/gsi/ https://www.googleapis.com https://sheets.googleapis.com https://oauth2.googleapis.com;"
+    />
     <!-- Google Identity Services -->
     <script src="https://accounts.google.com/gsi/client" async defer></script>
   </head>


### PR DESCRIPTION
## Summary
- update index.html with a CSP meta tag that whitelists `sheets.googleapis.com`

## Testing
- `npm run lint` *(fails: Could not find `no-dupe-imports` in plugin `@`)*

------
https://chatgpt.com/codex/tasks/task_e_686fa222b950832d8477cb70f26833ff